### PR TITLE
Fix template issues

### DIFF
--- a/templates/admin/metabox-sidebar.php
+++ b/templates/admin/metabox-sidebar.php
@@ -11,8 +11,8 @@
 ?>
 <?php wp_nonce_field( plugin_basename( WP_FEATHERLIGHT_FILE ), 'wp_featherlight_nonce' ); ?>
 <p>
-	<label for="meta-checkbox">
-		<input type="checkbox" name="wp_featherlight_disable" id="wp_featherlight_disable" value="yes" <?php esc_attr( checked( $checked, 'yes' ) ); ?> />
-		<?php _e( 'Disable Lightbox on This', 'wp-featherlight' ); ?> <?php echo $name; ?>
+	<label for="wp_featherlight_disable">
+		<input type="checkbox" name="wp_featherlight_disable" id="wp_featherlight_disable" value="yes"<?php checked( $checked, 'yes' ); ?> />
+		<?php esc_html_e( 'Disable Lightbox on This', 'wp-featherlight' ); ?> <?php echo $name; ?>
 	</label>
 </p>


### PR DESCRIPTION
- The label `for` attribute should match the `id` attribute of the input it is associated with.
- The label content output should be escaped.
- The output of `checked()` is not an attribute value so `esc_attr()` is wrong. It is considered pre-escaped as it's a hard-coded string.

Not addressed, is that the label content should use `sprintf()` and a placeholder `__()` string so that the `$name` value is included within the string - other languages may not put `$name` at the end of the string.
