### PR TITLE
Improve template label

### DIFF
--- a/templates/admin/metabox-sidebar.php
+++ b/templates/admin/metabox-sidebar.php
@@ -13,6 +13,6 @@
 <p>
 	<label for="wp_featherlight_disable">
 		<input type="checkbox" name="wp_featherlight_disable" id="wp_featherlight_disable" value="yes"<?php checked( $checked, 'yes' ); ?> />
-		<?php printf( esc_html__( 'Disable Lightbox on This %1$s', 'wp-featherlight' ), $name ); ?>
+		<?php echo esc_html( sprintf( _x( 'Disable Lightbox on This %s', '%s = post type singular name', 'wp-featherlight' ), $name ); ?>
 	</label>
 </p>


### PR DESCRIPTION
- Move escaping to the outside of the formatted print, so that any markup in the `$name` value is also escaped.
- Switch to using a contextual i18n function, to give translators a clue as to what the placeholder represents.

Fixes #5.
