### PR TITLE
Added filter for adding custom Featherlight galleries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 An ultra lightweight jQuery lightbox for WordPress images and galleries.
 
-__Contributors:__ [Robert Neu](https://github.com/robneu)  
-__Requires:__ WordPress 4.3  
-__Tested up to:__ WordPress 4.3  
-__License:__ [GPL-2.0+](http://www.gnu.org/licenses/gpl-2.0.html)  
+__Contributors:__ [Robert Neu](https://github.com/robneu)
+__Requires:__ WordPress 4.3
+__Tested up to:__ WordPress 4.3
+__License:__ [GPL-2.0+](http://www.gnu.org/licenses/gpl-2.0.html)
 
 ![nacin-at-loopconf](https://cloud.githubusercontent.com/assets/2184093/9426378/56c32f16-4902-11e5-9e57-75a4620cc51b.png)
 
@@ -36,6 +36,8 @@ The best way to install this plugin is to either [download a copy](https://wordp
 While there are no options in the plugin, there are some handy filters to modify the default behavior. As of `0.3.0` all images which use the default WordPress captions will also include a caption when the image is lightboxed. To disable this behavior, filter `wp_featherlight_captions` to false.
 
 You can also disable inclusion of the CSS and JavaScript conditionally using filters which can be found in the `/includes/class-scripts.php` file. If you have questions about how any part of the plugin works, please don't hesitate to [open an issue](https://github.com/wpsitecare/wp-featherlight/issues).
+
+Alongside the default WP galleries, you can set the container selectors of your own galleries. The filter which allows you to do that is `wp_featherlight_gallery_selectors`. It accepts one parameter (array) and your handler function should return array as well. Each item of an array is fully qualified CSS selector.
 
 ## Contributing ##
 

--- a/includes/class-scripts.php
+++ b/includes/class-scripts.php
@@ -42,6 +42,15 @@ class WP_Featherlight_Scripts {
 	protected $version;
 
 	/**
+	 * Array of CSS selectors which represent Featerlight gallery containers.
+	 *
+	 * @since  0.4.0
+	 * @access protected
+	 * @var    array
+	 */
+	protected $gallery_selectors;
+
+	/**
 	 * Set up required properties when the class is instantiated.
 	 *
 	 * @since  0.1.0
@@ -73,10 +82,22 @@ class WP_Featherlight_Scripts {
 	 * @return void
 	 */
 	protected function wp_hooks() {
-		add_action( 'wp_enqueue_scripts', array( $this, 'load_css' ),       20 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'load_js' ),        20 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_disable' ),  10 );
-		add_action( 'body_class',         array( $this, 'script_helpers' ), 10 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'load_css' ),              20 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'load_js' ),               20 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_disable' ),         10 );
+		add_action( 'body_class',         array( $this, 'script_helpers' ),        10 );
+		add_action( 'after_setup_theme',  array( $this, 'set_gallery_selectors' ), 10 );
+	}
+
+	/**
+	 * Apply filter and initialize the gallery_selectors property.
+	 *
+	 * @since 0.4.0
+	 * @access public
+	 * @return void
+	 */
+	public function set_gallery_selectors() {
+		$this->gallery_selectors = apply_filters( 'wp_featherlight_gallery_selectors', array( '.gallery', '.tiled-gallery' ) );
 	}
 
 	/**
@@ -119,6 +140,7 @@ class WP_Featherlight_Scripts {
 		}
 		$this->load_packed_js();
 		$this->load_unpacked_js();
+		$this->pass_data_to_js();
 	}
 
 	/**
@@ -238,5 +260,16 @@ class WP_Featherlight_Scripts {
 			$classes[] = 'wp-featherlight-captions';
 		}
 		return $classes;
+	}
+
+	/**
+	 * Pass JS object with data from backend to the JS.
+	 *
+	 * @since  0.4.0
+	 * @access protected
+	 * @return void
+	 */
+	protected function pass_data_to_js() {
+		wp_localize_script( 'wp-featherlight', 'wpFeatherlightObj', array( 'gallerySelectors' => $this->gallery_selectors ) );
 	}
 }

--- a/js/src/wpFeatherlight.js
+++ b/js/src/wpFeatherlight.js
@@ -1,3 +1,4 @@
+/* global wpFeatherlightObj */
 /**
  * WP Featherlight - Loader and helpers for the Featherlight WordPress plugin
  *
@@ -58,7 +59,13 @@
 	 * @return void
 	 */
 	function findGalleries() {
-		var $gallery = $( '.gallery, .tiled-gallery' );
+		var $gallery;
+
+		if ( wpFeatherlightObj && wpFeatherlightObj.gallerySelectors ) {
+			$gallery = $( wpFeatherlightObj.gallerySelectors.join(', ') );
+		} else {
+			$gallery = $( '.gallery, .tiled-gallery' );
+		}
 
 		if ( 0 === $gallery.length ) {
 			return;

--- a/js/src/wpFeatherlight.js
+++ b/js/src/wpFeatherlight.js
@@ -42,11 +42,7 @@
 	 */
 	function buildGalleries( index, element ) {
 		var $galleryObj   = $( element ),
-			$galleryItems = $galleryObj.find( '.gallery-item a' );
-
-		if ( 0 === $galleryItems.length ) {
-			$galleryItems = $galleryObj.find( '.tiled-gallery-item a' );
-		}
+			$galleryItems = $galleryObj.find( 'a[data-featherlight]' );
 
 		if ( ! $galleryItems.attr( 'data-featherlight' ) ) {
 			return;


### PR DESCRIPTION
Hi there guys!

Great plugin. We decided to use it in our newest theme.

However, I figured out that it was not possible for the devs to add a new galleries, as they were hardcoded in the `wpFeatherlight.js`. I've rewritten this (with backward-compatibility in mind) so it is now possible to define our own gallery containers with a new WP filter (see the docs change as well).

Tested and it works. The only thing I didn't do is to recompile the minified and packaged assets.

Otherwise, I think it is ready to be merged.

Thank you!
