### PR TITLE
Add support for Gutenberg galleries

### DIFF
--- a/assets/plugin/js/wpFeatherlight.js
+++ b/assets/plugin/js/wpFeatherlight.js
@@ -48,6 +48,10 @@
 			$galleryItems = $galleryObj.find( '.tiled-gallery-item a' );
 		}
 
+                if (0 === $galleryItems.length) {
+                       $galleryItems = $galleryObj.find('.blocks-gallery-item a');
+                }                
+
 		if ( $galleryItems.attr( 'data-featherlight' ) ) {
 			$galleryItems.featherlightGallery({
 				previousIcon: '',
@@ -63,7 +67,7 @@
 	 * @return void
 	 */
 	function findGalleries() {
-		var $gallery = $body.find( '.gallery, .tiled-gallery' );
+		var $gallery = $body.find( '.gallery, .tiled-gallery, .wp-block-gallery' );
 
 		if ( 0 !== $gallery.length ) {
 			$.each( $gallery, buildGalleries );

--- a/js/wpFeatherlight.js
+++ b/js/wpFeatherlight.js
@@ -47,6 +47,10 @@
 		if ( 0 === $galleryItems.length ) {
 			$galleryItems = $galleryObj.find( '.tiled-gallery-item a' );
 		}
+                
+                if (0 === $galleryItems.length) {
+                    $galleryItems = $galleryObj.find('.blocks-gallery-item a');
+                }
 
 		if ( $galleryItems.attr( 'data-featherlight' ) ) {
 			$galleryItems.featherlightGallery({
@@ -63,7 +67,7 @@
 	 * @return void
 	 */
 	function findGalleries() {
-		var $gallery = $body.find( '.gallery, .tiled-gallery' );
+		var $gallery = $body.find( '.gallery, .tiled-gallery, .wp-block-gallery' );
 
 		if ( 0 !== $gallery.length ) {
 			$.each( $gallery, buildGalleries );


### PR DESCRIPTION
As Gutenberg editor is announced to be merged in Wordpress core with the very next release 5.0 I think it could be good to start supporting its gallery format. As I already use it on my site I had to do committed changes to make gallery works. 
This pull request contains only base js file changes. During the build process, I got updated version of the featherlight jquery plugin got updated. I don't know if it's expected behaviour or side effect of some missing flags/commands I use while trying to prepare development environment.

BTW. It would be very useful if you could provide (very basic) CONTRIBUTIONS.md file which just lists the steps required to build all file required for full plugin release (except when you update them only during releasing). It could be just something like:
1. Clone forked repo
2. Run yarn install
3. Run bower install
4. Run grunt build
5. Commit all changes and generated files and create pull request