### PR TITLE
Only include images in gallery nav

### DIFF
--- a/js/wpFeatherlight.js
+++ b/js/wpFeatherlight.js
@@ -42,7 +42,7 @@
 	 */
 	function buildGalleries( index, element ) {
 		var $galleryObj   = $( element ),
-			$galleryItems = $galleryObj.find( '.gallery-item a' );
+			$galleryItems = $galleryObj.find( 'a[data-featherlight="image"]' );
 
 		if ( 0 === $galleryItems.length ) {
 			$galleryItems = $galleryObj.find( '.tiled-gallery-item a' );


### PR DESCRIPTION
Fixes #49 

Use more specific selector to keep links in captions out of gallery navigation