### PR TITLE
Add some margin to the caption

### DIFF
--- a/css/wp-featherlight-rtl.css
+++ b/css/wp-featherlight-rtl.css
@@ -71,6 +71,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.caption {
+  margin-top: 5px;
+}
 .featherlight .featherlight-content .caption:hover, .featherlight .featherlight-content .caption:focus {
   overflow: visible;
   white-space: normal;


### PR DESCRIPTION
The caption looks cramped against the image. I propose adding at least a 5px margin-top to the .caption class to make it look a bit more balanced by default.

Sorry if I messed up with the pull requests, I'm not very experienced with Github. Feel free to reject/cancel this if you see fit.